### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/batikutil/BatikUtil.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/batikutil/BatikUtil.java
@@ -38,6 +38,9 @@ import org.w3c.dom.svg.SVGPoint;
  * @since 0.3
  */
 public final class BatikUtil {
+  
+  private BatikUtil() {}
+  
   /**
    * Get the relative coordinates of a point within the coordinate system of a
    * particular SVG Element.

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/opticsplot/OPTICSCut.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/opticsplot/OPTICSCut.java
@@ -44,6 +44,9 @@ import de.lmu.ifi.dbs.elki.database.ids.ModifiableDBIDs;
  */
 // TODO: add non-flat clusterings
 public class OPTICSCut {
+  
+  private OPTICSCut() {}
+  
   /**
    * Compute an OPTICS cut clustering
    *

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/savedialog/SVGSaveDialog.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/savedialog/SVGSaveDialog.java
@@ -62,6 +62,9 @@ import de.lmu.ifi.dbs.elki.visualization.svg.SVGPlot;
  * @apiviz.composedOf SaveOptionsPanel
  */
 public class SVGSaveDialog {
+  
+  private SVGSaveDialog() {}
+  
   /** The default title. "Save as ...". */
   public static final String DEFAULT_TITLE = "Save as ...";
 

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGArrow.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGArrow.java
@@ -35,6 +35,9 @@ import org.w3c.dom.Element;
  * @apiviz.uses SVGPath
  */
 public final class SVGArrow {
+  
+  private SVGArrow() {}
+  
   /**
    * Direction constants
    * 

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGEffects.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGEffects.java
@@ -32,6 +32,9 @@ import org.w3c.dom.Element;
  * @since 0.5.0
  */
 public class SVGEffects {
+  
+  private SVGEffects() {}
+  
   /**
    * ID for the drop shadow effect
    */

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGHyperCube.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGHyperCube.java
@@ -45,6 +45,9 @@ import de.lmu.ifi.dbs.elki.visualization.projections.Projection2D;
  * @apiviz.uses Projection2D
  */
 public class SVGHyperCube {
+  
+  private SVGHyperCube() {}
+  
   /**
    * Wireframe hypercube.
    *

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGHyperSphere.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGHyperSphere.java
@@ -39,6 +39,9 @@ import de.lmu.ifi.dbs.elki.visualization.projections.Projection2D;
  * @apiviz.uses Projection2D
  */
 public class SVGHyperSphere {
+  
+  private SVGHyperSphere() {}
+  
   /**
    * Factor used for approximating circles with cubic beziers.
    *

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGUtil.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGUtil.java
@@ -56,6 +56,9 @@ import gnu.trove.map.hash.TObjectIntHashMap;
  * @apiviz.uses Element oneway - - «create»
  */
 public final class SVGUtil {
+  
+  private SVGUtil() {}
+  
   /**
    * Formatter to output numbers in a valid SVG number format.
    */

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/VoronoiDraw.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/VoronoiDraw.java
@@ -41,6 +41,9 @@ import de.lmu.ifi.dbs.elki.visualization.projections.Projection2D;
  * @apiviz.uses Projection2D
  */
 public class VoronoiDraw {
+  
+  private VoronoiDraw() {}
+  
   /**
    * Draw the Delaunay triangulation.
    * 

--- a/elki-core-dbids/src/main/java/de/lmu/ifi/dbs/elki/database/datastore/DataStoreUtil.java
+++ b/elki-core-dbids/src/main/java/de/lmu/ifi/dbs/elki/database/datastore/DataStoreUtil.java
@@ -40,6 +40,9 @@ import de.lmu.ifi.dbs.elki.database.ids.DBIDs;
  * @apiviz.composedOf de.lmu.ifi.dbs.elki.database.datastore.DataStoreFactory
  */
 public final class DataStoreUtil {
+  
+  private DataStoreUtil() {}
+  
   /**
    * Make a new storage, to associate the given ids with an object of class
    * dataclass.

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/BitsUtil.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/BitsUtil.java
@@ -40,6 +40,9 @@ import java.util.Arrays;
  * @since 0.5.0
  */
 public final class BitsUtil {
+  
+  private BitsUtil() {}
+  
   /**
    * Shift factor for a long: 2^6 == 64 == Long.SIZE
    */

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/arrays/DoubleIntegerArrayQuickSort.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/arrays/DoubleIntegerArrayQuickSort.java
@@ -31,6 +31,9 @@ package de.lmu.ifi.dbs.elki.utilities.datastructures.arrays;
  * @since 0.5.5
  */
 public class DoubleIntegerArrayQuickSort {
+  
+  private DoubleIntegerArrayQuickSort() {}
+  
   /**
    * Threshold for using insertion sort.
    */

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/arrays/IntegerArrayQuickSort.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/arrays/IntegerArrayQuickSort.java
@@ -47,6 +47,9 @@ import de.lmu.ifi.dbs.elki.utilities.documentation.Reference;
 title = "Dual-Pivot Quicksort", booktitle = "http://iaroslavski.narod.ru/quicksort/", //
 url = "http://iaroslavski.narod.ru/quicksort/")
 public class IntegerArrayQuickSort {
+  
+  private IntegerArrayQuickSort() {}
+  
   /**
    * Threshold for using insertion sort. Value taken from Javas QuickSort,
    * assuming that it will be similar for our data sets.

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/heap/HeapUtil.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/heap/HeapUtil.java
@@ -32,6 +32,9 @@ package de.lmu.ifi.dbs.elki.utilities.datastructures.heap;
  * @author Erich Schubert
  */
 public final class HeapUtil {
+  
+  private HeapUtil() {}
+  
   /**
    * Find the next power of 2.
    *

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/documentation/DocumentationUtil.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/documentation/DocumentationUtil.java
@@ -35,6 +35,9 @@ package de.lmu.ifi.dbs.elki.utilities.documentation;
  * @apiviz.uses de.lmu.ifi.dbs.elki.utilities.documentation.Reference
  */
 public final class DocumentationUtil {
+  
+  private DocumentationUtil() {}
+  
   /**
    * Get a useful title from a class, either by reading the
    * "title" annotation, or by using the class name.

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/io/FormatUtil.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/io/FormatUtil.java
@@ -43,6 +43,9 @@ import java.util.Locale;
  * @since 0.2
  */
 public final class FormatUtil {
+  
+  private FormatUtil() {}
+  
   /**
    * Dynamic number formatter, but with language constraint.
    */

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/io/ParseUtil.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/io/ParseUtil.java
@@ -30,6 +30,9 @@ import de.lmu.ifi.dbs.elki.utilities.datastructures.BitsUtil;
  * @author Erich Schubert
  */
 public final class ParseUtil {
+  
+  private ParseUtil() {}
+  
   /**
    * Preallocated exceptions.
    */

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/constraints/CommonConstraints.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/constraints/CommonConstraints.java
@@ -33,6 +33,9 @@ package de.lmu.ifi.dbs.elki.utilities.optionhandling.constraints;
  * @apiviz.composedOf ParameterConstraint
  */
 public final class CommonConstraints {
+  
+  private CommonConstraints() {}
+  
   /**
    * Integer constraint: >= -1
    */

--- a/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/application/internal/DocumentParameters.java
+++ b/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/application/internal/DocumentParameters.java
@@ -82,6 +82,9 @@ import de.lmu.ifi.dbs.elki.utilities.xml.HTMLUtil;
  * @apiviz.uses Parameter
  */
 public class DocumentParameters {
+  
+  private DocumentParameters() {}
+  
   private static final Logging LOG = Logging.getLogger(DocumentParameters.class);
 
   private static final String HEADER_PARAMETER_FOR = "Parameter for: ";

--- a/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/application/internal/DocumentReferences.java
+++ b/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/application/internal/DocumentReferences.java
@@ -64,6 +64,9 @@ import de.lmu.ifi.dbs.elki.utilities.xml.HTMLUtil;
  * @apiviz.uses Reference
  */
 public class DocumentReferences {
+  
+  private DocumentReferences() {}
+  
   private static final String CSSFILE = "stylesheet.css";
 
   private static final String MODIFICATION_WARNING = "WARNING: THIS DOCUMENT IS AUTOMATICALLY GENERATED. MODIFICATIONS MAY GET LOST.";

--- a/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/utilities/xml/HTMLUtil.java
+++ b/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/utilities/xml/HTMLUtil.java
@@ -43,6 +43,9 @@ import org.w3c.dom.Element;
  * @since 0.2
  */
 public final class HTMLUtil {
+  
+  private HTMLUtil() {}
+  
   /**
    * HTML namespace
    */

--- a/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/icons/StockIcon.java
+++ b/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/icons/StockIcon.java
@@ -97,6 +97,8 @@ public class StockIcon {
 
   private static final Map<String, SoftReference<Icon>> iconcache = new HashMap<>();
 
+  private StockIcon() {}
+  
   /**
    * Get a particular stock icon.
    * 

--- a/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/util/ClassTree.java
+++ b/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/util/ClassTree.java
@@ -38,6 +38,9 @@ import javax.swing.tree.TreeNode;
  * @apiviz.has TreeNode
  */
 public class ClassTree {
+    
+  private ClassTree() {}
+    
   /**
    * Build the class tree for a given set of choices.
    *

--- a/elki-logging/src/main/java/de/lmu/ifi/dbs/elki/logging/LoggingUtil.java
+++ b/elki-logging/src/main/java/de/lmu/ifi/dbs/elki/logging/LoggingUtil.java
@@ -40,6 +40,9 @@ import java.util.logging.Logger;
  * @apiviz.uses ELKILogRecord oneway - - «create»
  */
 public final class LoggingUtil {
+    
+    private LoggingUtil() {}
+    
   /**
    * Expensive logging function that is convenient, but should only be used in
    * rare conditions.

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/clustering/ClusteringAlgorithmUtil.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/clustering/ClusteringAlgorithmUtil.java
@@ -35,6 +35,9 @@ import de.lmu.ifi.dbs.elki.database.ids.DBIDs;
  * @since 0.7.0
  */
 public class ClusteringAlgorithmUtil {
+  
+  private ClusteringAlgorithmUtil() {}
+  
   /**
    * Collect clusters from their [0;k-1] integer labels.
    * 

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/application/ELKILauncher.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/application/ELKILauncher.java
@@ -39,6 +39,9 @@ import de.lmu.ifi.dbs.elki.utilities.ELKIServiceRegistry;
  * @apiviz.uses AbstractApplication
  */
 public class ELKILauncher {
+  
+  private ELKILauncher() {}
+  
   /**
    * Application to run by default.
    */

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/data/model/ModelUtil.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/data/model/ModelUtil.java
@@ -40,6 +40,9 @@ import de.lmu.ifi.dbs.elki.utilities.datastructures.arraylike.ArrayLikeUtil;
  * @apiviz.uses NumberVector
  */
 public final class ModelUtil {
+  
+  private ModelUtil() {}
+  
   /**
    * Get (and convert!) the representative vector for a cluster model.
    * 

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/database/QueryUtil.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/database/QueryUtil.java
@@ -61,6 +61,9 @@ import de.lmu.ifi.dbs.elki.distance.similarityfunction.SimilarityFunction;
  * @apiviz.has RKNNQuery
  */
 public final class QueryUtil {
+  
+  private QueryUtil() {}
+  
   /**
    * Get a distance query for a given distance function, automatically choosing
    * a relation.

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/index/tree/metrical/mtreevariants/query/MTreeQueryUtil.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/index/tree/metrical/mtreevariants/query/MTreeQueryUtil.java
@@ -35,6 +35,9 @@ import de.lmu.ifi.dbs.elki.index.tree.metrical.mtreevariants.AbstractMTree;
  * @since 0.5.5
  */
 public final class MTreeQueryUtil {
+  
+  private MTreeQueryUtil() {}
+  
   /**
    * Get an RTree knn query, using an optimized double implementation when
    * possible.

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/index/tree/spatial/rstarvariants/query/RStarTreeUtil.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/index/tree/spatial/rstarvariants/query/RStarTreeUtil.java
@@ -48,6 +48,9 @@ import de.lmu.ifi.dbs.elki.index.tree.spatial.rstarvariants.AbstractRStarTree;
  * @apiviz.has KNNQuery
  */
 public final class RStarTreeUtil {
+  
+  private RStarTreeUtil() {}
+  
   /**
    * Get an RTree range query, using an optimized double implementation when
    * possible.

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/math/statistics/ProbabilityWeightedMoments.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/math/statistics/ProbabilityWeightedMoments.java
@@ -49,6 +49,9 @@ import de.lmu.ifi.dbs.elki.utilities.documentation.Reference;
  */
 @Reference(authors = "J.R.M. Hosking, J. R. Wallis, and E. F. Wood", title = "Estimation of the generalized extreme-value distribution by the method of probability-weighted moments.", booktitle = "Technometrics 27.3", url = "http://dx.doi.org/10.1080/00401706.1985.10488049")
 public class ProbabilityWeightedMoments {
+  
+  private ProbabilityWeightedMoments() {}
+  
   /**
    * Compute the alpha_r factors using the method of probability-weighted
    * moments.

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/parallel/ParallelExecutor.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/parallel/ParallelExecutor.java
@@ -50,6 +50,9 @@ import de.lmu.ifi.dbs.elki.parallel.variables.SharedVariable.Instance;
  * @apiviz.uses ParallelCore
  */
 public class ParallelExecutor {
+  
+  private ParallelExecutor() {}
+  
   /**
    * Run a task on all available CPUs.
    * 

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/parallel/SingleThreadedExecutor.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/parallel/SingleThreadedExecutor.java
@@ -42,6 +42,9 @@ import de.lmu.ifi.dbs.elki.parallel.variables.SharedVariable.Instance;
  * @apiviz.has SingleThreadedRunner
  */
 public class SingleThreadedExecutor {
+  
+  private SingleThreadedExecutor() {}
+  
   /**
    * Run a task on a single thread.
    * 

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/result/ResultUtil.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/result/ResultUtil.java
@@ -47,6 +47,9 @@ import de.lmu.ifi.dbs.elki.utilities.datastructures.hierarchy.Hierarchy;
  * @apiviz.uses Result oneway - - filters
  */
 public class ResultUtil {
+  
+  private ResultUtil() {}
+  
   /**
    * Collect all Annotation results from a Result
    *

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/QuickSelect.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/QuickSelect.java
@@ -48,6 +48,9 @@ import de.lmu.ifi.dbs.elki.database.ids.ModifiableDoubleDBIDList;
  * @apiviz.uses Adapter
  */
 public class QuickSelect {
+  
+  private QuickSelect() {}
+  
   /**
    * For small arrays, use a simpler method:
    */

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/unionfind/UnionFindUtil.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/unionfind/UnionFindUtil.java
@@ -32,6 +32,9 @@ import de.lmu.ifi.dbs.elki.database.ids.StaticDBIDs;
  * @since 0.7.0
  */
 public class UnionFindUtil {
+  
+  private UnionFindUtil() {}
+  
   /**
    * Make a new instance (automatically choosing the best implementation).
    *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
