### PR TITLE
Bugfix: fixed incorrrect typing in outlier histogram computation

### DIFF
--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/evaluation/histogram/ComputeOutlierHistogram.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/evaluation/histogram/ComputeOutlierHistogram.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import de.lmu.ifi.dbs.elki.data.DoubleVector;
 import de.lmu.ifi.dbs.elki.database.Database;
 import de.lmu.ifi.dbs.elki.database.DatabaseUtil;
 import de.lmu.ifi.dbs.elki.database.ids.DBIDIter;
@@ -151,7 +152,7 @@ public class ComputeOutlierHistogram implements Evaluator {
    * @param or Outlier result
    * @return Result
    */
-  public HistogramResult<double[]> evaluateOutlierResult(Database database, OutlierResult or) {
+  public HistogramResult<DoubleVector> evaluateOutlierResult(Database database, OutlierResult or) {
     if(scaling instanceof OutlierScalingFunction) {
       OutlierScalingFunction oscaling = (OutlierScalingFunction) scaling;
       oscaling.prepare(or);
@@ -239,10 +240,10 @@ public class ComputeOutlierHistogram implements Evaluator {
         hist.putData(result, positive);
       }
     }
-    Collection<double[]> collHist = new ArrayList<>(hist.getNumBins());
+    Collection<DoubleVector> collHist = new ArrayList<>(hist.getNumBins());
     for(ObjHistogram.Iter<DoubleDoublePair> iter = hist.iter(); iter.valid(); iter.advance()) {
       DoubleDoublePair data = iter.getValue();
-      collHist.add(new double[] { iter.getCenter(), data.first, data.second });
+      collHist.add(new DoubleVector(new double[] { iter.getCenter(), data.first, data.second }));
     }
     return new HistogramResult<>("Outlier Score Histogram", "outlier-histogram", collHist);
   }


### PR DESCRIPTION
When using the automatic visualisation for LOF and other outlier algorithms, the following exception would be thrown:

    java.lang.ClassCastException: [D cannot be cast to de.lmu.ifi.dbs.elki.data.NumberVector
    	at de.lmu.ifi.dbs.elki.visualization.visualizers.visunproj.HistogramVisualization.makeVisualization(HistogramVisualization.java:96)
    	at de.lmu.ifi.dbs.elki.visualization.gui.overview.OverviewPlot.embedOrThumbnail(OverviewPlot.java:420)
    	at de.lmu.ifi.dbs.elki.visualization.gui.overview.OverviewPlot.reinitialize(OverviewPlot.java:322)
    	at de.lmu.ifi.dbs.elki.visualization.gui.overview.OverviewPlot.initialize(OverviewPlot.java:256)
    	at de.lmu.ifi.dbs.elki.visualization.gui.ResultWindow.<init>(ResultWindow.java:504)
    	at de.lmu.ifi.dbs.elki.result.AutomaticVisualization.processNewResult(AutomaticVisualization.java:112)
    	at de.lmu.ifi.dbs.elki.workflow.OutputStep.runResultHandlers(OutputStep.java:73)
    	at de.lmu.ifi.dbs.elki.KDDTask.run(KDDTask.java:121)
    	at de.lmu.ifi.dbs.elki.application.KDDCLIApplication.run(KDDCLIApplication.java:61)
    	at [...]

I tracked the problem to the creation of the histogram result which is expected to contain NumberVectors, but instead contained arrays of doubles. With this change, the visualisation works as expected.