### PR TITLE
Bugfix: label rows are now also detected when preceded by comment rows

### DIFF
--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/NumberVectorLabelParser.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/NumberVectorLabelParser.java
@@ -287,7 +287,7 @@ public class NumberVectorLabelParser<V extends NumberVector> extends AbstractStr
       }
     }
     // Maybe a label row?
-    if(reader.getLineNumber() == 1 && attributes.size == 0) {
+    if(curvec == null && attributes.size == 0) {
       columnnames = new ArrayList<>(labels);
       haslabels = false;
       curvec = null;


### PR DESCRIPTION
If an input file starts with one or more comment lines, followed by a line containing labels, those labels are not parsed since originally labels would only be detected on line 1. Since `curvec` is only set when a vector row is parsed, it will always be `null` when the label row is parsed. This is therefore a more reliable way to detect label rows.

An alternative way to fix this would be to count non-comment line numbers in the `TokenizedReader`. However, this is a less elegant solution in my opinion while it also requires a closer coupling between `NumberVectorLabelParser` and `TokenizedReader`.