### PR TITLE
Bugfix: Clear labels after reading header row

### DIFF
--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/NumberVectorLabelParser.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/NumberVectorLabelParser.java
@@ -292,6 +292,7 @@ public class NumberVectorLabelParser<V extends NumberVector> extends AbstractStr
       haslabels = false;
       curvec = null;
       curlbl = null;
+      labels.clear();
       return false;
     }
     // Pass outside via class variables


### PR DESCRIPTION
When the labels are not cleared after reading a header row, the first data row will have the titles in the header row as well as its own label set as the label. This causes the creation of an extra, non existing, cluster. Clearing the labels after creating the header row solves this problem.