### PR TITLE
Partial code cleanup based on IDE warnings

### DIFF
--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/VisualizationTask.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/VisualizationTask.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -248,7 +248,7 @@ public class VisualizationTask implements VisualizationItem, Comparable<Visualiz
     // sort by name otherwise.
     String name1 = this.getMenuName();
     String name2 = other.getMenuName();
-    if(name1 != null && name2 != null && name1 != name2) {
+    if(name1 != null && name2 != null && !name1.equals(name2)) {
       return name1.compareTo(name2);
     }
     return 0;

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/gui/ResultWindow.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/gui/ResultWindow.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization.gui;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -465,10 +465,10 @@ public class ResultWindow extends JFrame implements ResultListener, Visualizatio
         if(e instanceof DetailViewSelectedEvent) {
           showSubplot((DetailViewSelectedEvent) e);
         }
-        if(OverviewPlot.OVERVIEW_REFRESHING == e.getActionCommand() && currentSubplot == null) {
+        if(OverviewPlot.OVERVIEW_REFRESHING.equals(e.getActionCommand()) && currentSubplot == null) {
           showPlot(null);
         }
-        if(OverviewPlot.OVERVIEW_REFRESHED == e.getActionCommand() && currentSubplot == null) {
+        if(OverviewPlot.OVERVIEW_REFRESHED.equals(e.getActionCommand()) && currentSubplot == null) {
           showOverview();
         }
       }

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/gui/SelectionTableWindow.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/gui/SelectionTableWindow.java
@@ -3,7 +3,7 @@ package de.lmu.ifi.dbs.elki.visualization.gui;
 This file is part of ELKI:
 Environment for Developing KDD-Applications Supported by Index-Structures
 
-Copyright (C) 2015
+Copyright (C) 2016
 Ludwig-Maximilians-Universität München
 Lehr- und Forschungseinheit für Datenbanksysteme
 ELKI Development Team
@@ -290,10 +290,7 @@ public class SelectionTableWindow extends JFrame implements DataStoreListener, R
 
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-      if(columnIndex == 0) {
-        return false;
-      }
-      return true;
+      return columnIndex != 0;
     }
 
     @Override

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/gui/detail/DetailView.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/gui/detail/DetailView.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization.gui.detail;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -407,9 +407,7 @@ public class DetailView extends VisualizationPlot implements ResultListener, Vis
         vis.incrementalRedraw();
       }
     }
-    if(active || true) {
-      refresh();
-    }
+    refresh();
   }
 
   /**

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGPath.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/svg/SVGPath.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization.svg;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -29,6 +29,8 @@ import org.w3c.dom.Element;
 
 import de.lmu.ifi.dbs.elki.data.spatial.Polygon;
 import de.lmu.ifi.dbs.elki.utilities.datastructures.iterator.ArrayListIter;
+
+import java.util.Objects;
 
 /**
  * Element used for building an SVG path using a string buffer.
@@ -635,7 +637,7 @@ public class SVGPath {
    * @param ds coordinates.
    */
   private void append(String action, double... ds) {
-    if(lastaction != action) {
+    if(!Objects.equals(lastaction, action)) {
       buf.append(action);
       lastaction = action;
     }
@@ -651,7 +653,7 @@ public class SVGPath {
    * @return path object, for compact syntax.
    */
   public SVGPath close() {
-    if(lastaction != SVGConstants.PATH_CLOSE) {
+    if(!Objects.equals(lastaction, SVGConstants.PATH_CLOSE)) {
       buf.append(SVGConstants.PATH_CLOSE);
       lastaction = SVGConstants.PATH_CLOSE;
     }

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/histogram/AbstractHistogramVisualization.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/histogram/AbstractHistogramVisualization.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization.visualizers.histogram;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -65,7 +65,6 @@ public abstract class AbstractHistogramVisualization extends AbstractVisualizati
     super.resultChanged(current);
     if(proj != null && current == proj) {
       svgp.requestRedraw(this.task, this);
-      return;
     }
   }
 }

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/parallel/AbstractParallelVisualization.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/parallel/AbstractParallelVisualization.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization.visualizers.parallel;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -165,7 +165,6 @@ public abstract class AbstractParallelVisualization<NV> extends AbstractVisualiz
     if(item == proj) {
       recalcAxisPositions();
       svgp.requestRedraw(this.task, this);
-      return;
     }
   }
 }

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/scatterplot/AbstractScatterplotVisualization.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/scatterplot/AbstractScatterplotVisualization.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization.visualizers.scatterplot;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -119,7 +119,6 @@ public abstract class AbstractScatterplotVisualization extends AbstractVisualiza
     super.visualizationChanged(item);
     if(item == proj) {
       svgp.requestRedraw(this.task, this);
-      return;
     }
   }
 }

--- a/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/scatterplot/TooltipStringVisualization.java
+++ b/addons/batikvis/src/main/java/de/lmu/ifi/dbs/elki/visualization/visualizers/scatterplot/TooltipStringVisualization.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.visualization.visualizers.scatterplot;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -172,7 +172,7 @@ public class TooltipStringVisualization extends AbstractVisFactory {
     protected Element makeTooltip(DBIDRef id, double x, double y, double dotsize) {
       final Object data = result.get(id);
       String label = (data == null) ? "null" : data.toString();
-      label = (label == "" || label == null) ? "null" : label;
+      label = (label == null || label.equals("")) ? "null" : label;
       return svgp.svgText(x + dotsize, y + fontsize * 0.07, label);
     }
 

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/BitsUtil.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/datastructures/BitsUtil.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.utilities.datastructures;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -353,9 +353,7 @@ public final class BitsUtil {
   public static long[] setI(long[] v, long[] o) {
     assert (o.length <= v.length) : "Bit set sizes do not agree.";
     final int max = Math.min(v.length, o.length);
-    for(int i = 0; i < max; i++) {
-      v[i] = o[i];
-    }
+    System.arraycopy(o, 0, v, 0, max);
     return v;
   }
 

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/io/ByteArrayUtil.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/io/ByteArrayUtil.java
@@ -853,13 +853,13 @@ public final class ByteArrayUtil {
       @Override
       public Object run() {
         try {
-          Method getCleanerMethod = map.getClass().getMethod("cleaner", new Class[0]);
+          Method getCleanerMethod = map.getClass().getMethod("cleaner");
           if(getCleanerMethod == null) {
             return null;
           }
 
           getCleanerMethod.setAccessible(true);
-          Object cleaner = getCleanerMethod.invoke(map, new Object[0]);
+          Object cleaner = getCleanerMethod.invoke(map);
           Method cleanMethod = cleaner.getClass().getMethod("clean");
           if(cleanMethod == null) {
             return null;

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/parameterization/ChainedParameterization.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/parameterization/ChainedParameterization.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.utilities.optionhandling.parameterization;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -24,6 +24,7 @@ package de.lmu.ifi.dbs.elki.utilities.optionhandling.parameterization;
  */
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import de.lmu.ifi.dbs.elki.utilities.optionhandling.ParameterException;
@@ -58,9 +59,7 @@ public class ChainedParameterization extends AbstractParameterization {
    * @param ps Parameterizations
    */
   public ChainedParameterization(Parameterization... ps) {
-    for(Parameterization p : ps) {
-      chain.add(p);
-    }
+    Collections.addAll(chain, ps);
     //logger.warning("Chain length: "+chain.size()+ " for "+this);
   }
 

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/parameterization/SerializedParameterization.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/parameterization/SerializedParameterization.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.utilities.optionhandling.parameterization;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -23,6 +23,7 @@ package de.lmu.ifi.dbs.elki.utilities.optionhandling.parameterization;
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -70,9 +71,7 @@ public class SerializedParameterization extends AbstractParameterization {
    */
   public SerializedParameterization(String[] args) {
     this();
-    for (String arg : args) {
-      parameters.add(arg);
-    }
+    Collections.addAll(parameters, args);
   }
 
   /**

--- a/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/parameters/ClassParameter.java
+++ b/elki-core-util/src/main/java/de/lmu/ifi/dbs/elki/utilities/optionhandling/parameters/ClassParameter.java
@@ -148,10 +148,7 @@ public class ClassParameter<C> extends AbstractParameter<ClassParameter<C>, Clas
     if(!restrictionClass.isAssignableFrom(obj)) {
       throw new WrongParameterValueException(this, obj.getName(), "Given class not a subclass / implementation of " + restrictionClass.getName());
     }
-    if(!super.validate(obj)) {
-      return false;
-    }
-    return true;
+    return super.validate(obj);
   }
 
   /**

--- a/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/application/internal/DocumentReferences.java
+++ b/elki-docutil/src/main/java/de/lmu/ifi/dbs/elki/application/internal/DocumentReferences.java
@@ -31,14 +31,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeSet;
+import java.util.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -333,7 +326,7 @@ public class DocumentReferences {
        * @return Order
        */
       private int compareNull(String s1, String s2) {
-        return (s1 == s2) ? 0 //
+        return (Objects.equals(s1, s2)) ? 0 //
             : (s1 == null) ? -1 //
                 : (s2 == null) ? +1 //
                     : s1.compareTo(s2);

--- a/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/configurator/ClassListParameterConfigurator.java
+++ b/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/configurator/ClassListParameterConfigurator.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.gui.configurator;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -29,6 +29,7 @@ import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Objects;
 
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -167,7 +168,7 @@ public class ClassListParameterConfigurator extends AbstractSingleParameterConfi
       return;
     }
     if(e.getSource() == popup) {
-      if(e.getActionCommand() == TreePopup.ACTION_CANCELED) {
+      if(Objects.equals(e.getActionCommand(), TreePopup.ACTION_CANCELED)) {
         popup.setVisible(false);
         textfield.requestFocus();
         return;

--- a/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/configurator/ClassParameterConfigurator.java
+++ b/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/configurator/ClassParameterConfigurator.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.gui.configurator;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -29,6 +29,7 @@ import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Objects;
 
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -174,7 +175,7 @@ public class ClassParameterConfigurator extends AbstractSingleParameterConfigura
       return;
     }
     if(e.getSource() == popup) {
-      if (e.getActionCommand() == TreePopup.ACTION_CANCELED) {
+      if (Objects.equals(e.getActionCommand(), TreePopup.ACTION_CANCELED)) {
         popup.setVisible(false);
         textfield.requestFocus();
         return;

--- a/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/multistep/panels/ParameterTabPanel.java
+++ b/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/multistep/panels/ParameterTabPanel.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.gui.multistep.panels;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -313,10 +313,7 @@ public abstract class ParameterTabPanel extends JPanel implements ChangeListener
    */
   public boolean canRun() {
     Status status = getStatus();
-    if (Status.STATUS_READY.equals(status) || Status.STATUS_COMPLETE.equals(status)) {
-      return true;
-    }
-    return false;
+    return Status.STATUS_READY.equals(status) || Status.STATUS_COMPLETE.equals(status);
   }
 
   /**
@@ -326,10 +323,7 @@ public abstract class ParameterTabPanel extends JPanel implements ChangeListener
    */
   public boolean isComplete() {
     Status status = getStatus();
-    if (Status.STATUS_COMPLETE.equals(status)) {
-      return true;
-    }
-    return false;
+    return Status.STATUS_COMPLETE.equals(status);
   }
 
   /**

--- a/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/util/ParameterTable.java
+++ b/elki-gui-minigui/src/main/java/de/lmu/ifi/dbs/elki/gui/util/ParameterTable.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.gui.util;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -34,6 +34,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.io.File;
+import java.util.Objects;
 
 import javax.swing.AbstractCellEditor;
 import javax.swing.Action;
@@ -338,7 +339,7 @@ public class ParameterTable extends JTable {
         if(sval.startsWith(DynamicParameters.STRING_USE_DEFAULT)) {
           sval = "";
         }
-        if(sval != "") {
+        if(!sval.equals("")) {
           comboBox.addItem(sval);
           comboBox.setSelectedIndex(0);
         }
@@ -573,7 +574,7 @@ public class ParameterTable extends JTable {
         return;
       }
       if(e.getSource() == popup) {
-        if(e.getActionCommand() == TreePopup.ACTION_CANCELED) {
+        if(Objects.equals(e.getActionCommand(), TreePopup.ACTION_CANCELED)) {
           popup.setVisible(false);
           textfield.requestFocus();
           return;

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/clustering/kmeans/initialization/PredefinedInitialMeans.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/clustering/kmeans/initialization/PredefinedInitialMeans.java
@@ -5,7 +5,7 @@ package de.lmu.ifi.dbs.elki.algorithm.clustering.kmeans.initialization;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -94,9 +94,7 @@ public class PredefinedInitialMeans extends AbstractKMeansInitialization<NumberV
    */
   public void setInitialMeans(double[][] initialMeans) {
     double[][] vecs = new double[initialMeans.length][];
-    for(int i = 0; i < initialMeans.length; ++i) {
-      vecs[i] = initialMeans[i]; // TODO: clone?
-    }
+    System.arraycopy(initialMeans, 0, vecs, 0, initialMeans.length);
     this.initialMeans = vecs;
   }
 

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/statistics/DistanceQuantileSampler.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/statistics/DistanceQuantileSampler.java
@@ -3,7 +3,7 @@ package de.lmu.ifi.dbs.elki.algorithm.statistics;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -24,6 +24,7 @@ package de.lmu.ifi.dbs.elki.algorithm.statistics;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Random;
 
 import de.lmu.ifi.dbs.elki.algorithm.AbstractDistanceBasedAlgorithm;
@@ -151,7 +152,7 @@ public class DistanceQuantileSampler<O> extends AbstractDistanceBasedAlgorithm<O
     LOG.statistics(new LongStatistic(PREFIX + ".samplesize", ssize));
     LOG.statistics(new DoubleStatistic(PREFIX + ".distance", heap.peek()));
     LOG.ensureCompleted(prog);
-    Collection<String> header = Arrays.asList(new String[] { "Distance" });
+    Collection<String> header = Collections.singletonList("Distance");
     Collection<double[]> data = Arrays.asList(new double[][] { new double[] { heap.peek() } });
     return new CollectionResult<double[]>("Distances sample", "distance-sample", data, header);
   }

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/data/BitVector.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/data/BitVector.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.data;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -99,7 +99,7 @@ public class BitVector extends AbstractNumberVector implements SparseNumberVecto
   @Override
   @Deprecated
   public Bit getValue(int dimension) {
-    return new Bit(booleanValue(dimension));
+    return Bit.valueOf(booleanValue(dimension));
   }
 
   @Override

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/ClusteringVectorParser.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/ClusteringVectorParser.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.datasource.parser;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -152,7 +152,7 @@ public class ClusteringVectorParser extends AbstractStreamingParser {
       return ret;
     }
     try {
-      while(reader.nextLineExceptComments()) {
+      if(reader.nextLineExceptComments()) {
         buf1.clear();
         lbl.clear();
         TIntIntMap csize = new TIntIntHashMap();

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/SimpleTransactionParser.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/datasource/parser/SimpleTransactionParser.java
@@ -4,7 +4,7 @@ package de.lmu.ifi.dbs.elki.datasource.parser;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -118,7 +118,7 @@ public class SimpleTransactionParser extends AbstractStreamingParser {
       return ret;
     }
     try {
-      while(reader.nextLineExceptComments()) {
+      if(reader.nextLineExceptComments()) {
         // Don't reuse bitsets, will not be copied by BitVector constructor.
         buf.clear();
         for(/* initialized by nextLineExceptComments() */; tokenizer.valid(); tokenizer.advance()) {

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/index/preprocessed/fastoptics/RandomProjectedNeighborsAndDensities.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/index/preprocessed/fastoptics/RandomProjectedNeighborsAndDensities.java
@@ -7,7 +7,7 @@ package de.lmu.ifi.dbs.elki.index.preprocessed.fastoptics;
  This file is part of ELKI:
  Environment for Developing KDD-Applications Supported by Index-Structures
 
- Copyright (C) 2015
+ Copyright (C) 2016
  Ludwig-Maximilians-Universität München
  Lehr- und Forschungseinheit für Datenbanksysteme
  ELKI Development Team
@@ -224,9 +224,7 @@ public class RandomProjectedNeighborsAndDensities<V extends NumberVector> {
     FiniteProgress splitp = LOG.isVerbose() ? new FiniteProgress("Splitting data", nPointSetSplits, LOG) : null;
     for(int avgP = 0; avgP < nPointSetSplits; avgP++) {
       // shuffle projections
-      for(int i = 0; i < nProject1d; i++) {
-        tmpPro[i] = projectedPoints[i];
-      }
+      System.arraycopy(projectedPoints, 0, tmpPro, 0, nProject1d);
       proind.shuffle(rand);
       TIntIterator it = proind.iterator();
       int i = 0;


### PR DESCRIPTION
Based on warnings from my IDE, I did some code cleaning. The issues I fixed fall in the following categories:

- Use `System.arraycopy` instead of manual iteration.
- Use `Collections` methods instead of manual iterator or redundant array initialisation.
- Replace uses of deprecated methods.
- Replace non-looping `while` loops by `if`-statements.
- Remove redundant `if`-statements.
- Use `Objects`' `equals` method instead of string comparison using `==` or `!=`.
- Replace unnecessarily verbose `if`-statements.
- Remove redundant `return`-statements.

Additionally, I updated the copyright year for the files I modified.