### PR TITLE
Fix two lgtm.com alerts: comparisons using '==' and '!=' operators only test for reference equality

### DIFF
--- a/elki-index/src/main/java/de/lmu/ifi/dbs/elki/index/tree/AbstractDirectoryEntry.java
+++ b/elki-index/src/main/java/de/lmu/ifi/dbs/elki/index/tree/AbstractDirectoryEntry.java
@@ -128,7 +128,7 @@ public abstract class AbstractDirectoryEntry implements DirectoryEntry {
 
     final AbstractDirectoryEntry that = (AbstractDirectoryEntry) o;
 
-    return id == that.id;
+    return id.intValue() == that.id.intValue();
   }
 
   /**

--- a/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/clustering/correlation/cash/CASHInterval.java
+++ b/elki/src/main/java/de/lmu/ifi/dbs/elki/algorithm/clustering/correlation/cash/CASHInterval.java
@@ -282,7 +282,7 @@ public class CASHInterval extends HyperBoundingBox implements Comparable<CASHInt
     }
 
     final CASHInterval interval = (CASHInterval) o;
-    if(intervalID != interval.intervalID) {
+    if(intervalID.intValue() != interval.intervalID.intValue()) {
       return false;
     }
     return super.equals(o);


### PR DESCRIPTION
I hope this is the right way to contribute!

Just wanted to quickly fix these alerts flagged up on lgtm.com. Using the '==' and '!=' operators on boxed integers only tests for reference equality, rather than for value equality. 

More details:
 - AbstractDirectoryEntry: https://lgtm.com/projects/g/elki-project/elki/snapshot/6012705b63d63424bed08d3f4c459c6149d64115/files/elki-index/src/main/java/de/lmu/ifi/dbs/elki/index/tree/AbstractDirectoryEntry.java#L131
 - CASHInterval: https://lgtm.com/projects/g/elki-project/elki/snapshot/6012705b63d63424bed08d3f4c459c6149d64115/files/elki-index/src/main/java/de/lmu/ifi/dbs/elki/index/tree/AbstractDirectoryEntry.java#L131

A total of 160 alerts have been flagged up by lgtm.com: https://lgtm.com/projects/g/elki-project/elki/alerts/

Tip: enable pull request integration for fully automated PR reviews to make sure tiny mistakes like these do not actually get past code review.