### PR TITLE
Feature/set distance tests

### DIFF
--- a/elki-core-data/src/main/java/elki/data/BitVector.java
+++ b/elki-core-data/src/main/java/elki/data/BitVector.java
@@ -212,7 +212,8 @@ public class BitVector implements SparseNumberVector {
    * @return Jaccard similarity (intersection / union)
    */
   public double jaccardSimilarity(BitVector v2) {
-    return BitsUtil.intersectionSize(bits, v2.bits) / (double) BitsUtil.unionSize(bits, v2.bits);
+    int union =  BitsUtil.unionSize(bits, v2.bits);
+    return union == 0? 1:BitsUtil.intersectionSize(bits, v2.bits) / (double)union;
   }
 
   /**

--- a/elki-core-distance/src/main/java/elki/distance/set/JaccardSimilarityDistance.java
+++ b/elki-core-distance/src/main/java/elki/distance/set/JaccardSimilarityDistance.java
@@ -109,7 +109,7 @@ public class JaccardSimilarityDistance extends AbstractSetDistance<FeatureVector
         ++union;
       }
     }
-    return intersection / (double) union;
+    return union == 0? 1: intersection / (double) union;
   }
 
   /**
@@ -145,7 +145,7 @@ public class JaccardSimilarityDistance extends AbstractSetDistance<FeatureVector
         ++union;
       }
     }
-    return intersection / (double) union;
+    return union == 0? 1: intersection / (double) union;
   }
 
   @Override

--- a/elki-core-distance/src/test/java/elki/distance/IntegerFeatureVector.java
+++ b/elki-core-distance/src/test/java/elki/distance/IntegerFeatureVector.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of ELKI:
+ * Environment for Developing KDD-Applications Supported by Index-Structures
+ *
+ * Copyright (C) 2019
+ * ELKI Development Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package elki.distance;
+import elki.data.FeatureVector;
+
+public class IntegerFeatureVector implements FeatureVector<Integer>{
+  int[] data;
+  
+  public IntegerFeatureVector(int... data) {
+    this.data = data;
+  }
+  @Override
+  public int getDimensionality() {
+    return data.length;
+  }
+
+  @Override
+  public Integer getValue(int dimension) {
+    if(dimension >= 0 || dimension < data.length )return data[dimension];
+    return null;
+  }
+
+}

--- a/elki-core-distance/src/test/java/elki/distance/set/AbstractSetDistanceTest.java
+++ b/elki-core-distance/src/test/java/elki/distance/set/AbstractSetDistanceTest.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of ELKI:
+ * Environment for Developing KDD-Applications Supported by Index-Structures
+ *
+ * Copyright (C) 2019
+ * ELKI Development Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package elki.distance.set;
+
+import static org.junit.Assert.assertEquals;
+
+import elki.data.BitVector;
+import elki.data.FeatureVector;
+import elki.data.IntegerVector;
+import elki.distance.AbstractDistanceTest;
+import elki.distance.IntegerFeatureVector;
+
+public abstract class AbstractSetDistanceTest extends AbstractDistanceTest {
+  /**
+   * BitVectors for Set testing
+   */
+  final BitVector[] VECTORS = { new BitVector(new long[] { 0b11100_00000L }, 10), // a
+      new BitVector(new long[] { 0b00011_11111L }, 10), // b
+      new BitVector(new long[] { 0b10101_01010L }, 10), // c
+      new BitVector(new long[] { 0b11111_11111L }, 10), // d
+      new BitVector(new long[] { 0b00000_00000L }, 10) // e
+  };
+
+  /**
+   * Test setup pairs
+   */
+  final BitVector[][] TESTS = { { VECTORS[0], VECTORS[1] }, { VECTORS[2], VECTORS[3] }, { VECTORS[2], VECTORS[4] }, { VECTORS[0], VECTORS[2] }, { VECTORS[1], VECTORS[3] }, { VECTORS[4], VECTORS[4] } };
+
+  /**
+   * IntegerFeatureVector for Set testing
+   * 
+   */
+  final IntegerFeatureVector[] INTFEATVECTORS = { new IntegerFeatureVector(new int[] { 1, 1, 1, 0, 0, 0, 0, 0, 0, 0 }), // a
+      new IntegerFeatureVector(new int[] { 0, 0, 0, 1, 1, 1, 1, 1, 1, 1 }), // b
+      new IntegerFeatureVector(new int[] { 1, 0, 1, 0, 1, 0, 1, 0, 1, 0 }), // c
+      new IntegerFeatureVector(new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }), // d
+      new IntegerFeatureVector(new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }), // e
+      new IntegerFeatureVector(new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1 }), // f
+      new IntegerFeatureVector(new int[] { 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0 }) // g
+  };
+
+  /**
+   * Test setup pairs
+   */
+  final IntegerFeatureVector[][] INTFEATTESTS = { { INTFEATVECTORS[0], INTFEATVECTORS[1] }, { INTFEATVECTORS[2], INTFEATVECTORS[3] }, { INTFEATVECTORS[2], INTFEATVECTORS[4] }, { INTFEATVECTORS[0], INTFEATVECTORS[2] }, { INTFEATVECTORS[1], INTFEATVECTORS[3] }, { INTFEATVECTORS[4], INTFEATVECTORS[4] } };
+
+  /**
+   * Tests the given Distance function using Bitvectors
+   * 
+   * @param tolerance tolerance used for floating point distances
+   * @param distfunc the distance function to test
+   * @param results An array of results for the given Testcases
+   */
+  public void bitVectorSet(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double... results) {
+    assertEquals(results[0], distfunc.distance(TESTS[0][0], TESTS[0][1]), tolerance);
+    assertEquals(results[1], distfunc.distance(TESTS[1][0], TESTS[1][1]), tolerance);
+    assertEquals(results[2], distfunc.distance(TESTS[2][0], TESTS[2][1]), tolerance);
+    assertEquals(results[3], distfunc.distance(TESTS[3][0], TESTS[3][1]), tolerance);
+    assertEquals(results[4], distfunc.distance(TESTS[4][0], TESTS[4][1]), tolerance);
+    // assertEquals(results[5], distfunc.distance(TESTS[5][0],
+    // TESTS[5][1]),tolerance);
+  }
+
+  /**
+   * Tests the given Distance function using (Int)-Numbervectors
+   * 
+   * @param tolerance tolerance used for floating point distances
+   * @param distfunc the distance function to test
+   * @param results An array of results for the given Testcases
+   */
+  public void numberVectorSet(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double... results) {
+    assertEquals(results[0], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[0][0]), IntegerVector.STATIC.newNumberVector(TESTS[0][1])), tolerance);
+    assertEquals(results[1], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[1][0]), IntegerVector.STATIC.newNumberVector(TESTS[1][1])), tolerance);
+    assertEquals(results[2], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[2][0]), IntegerVector.STATIC.newNumberVector(TESTS[2][1])), tolerance);
+    assertEquals(results[3], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[3][0]), IntegerVector.STATIC.newNumberVector(TESTS[3][1])), tolerance);
+    assertEquals(results[4], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[4][0]), IntegerVector.STATIC.newNumberVector(TESTS[4][1])), tolerance);
+    // assertEquals(results[5],
+    // distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[5][0]),IntegerVector.STATIC.newNumberVector(TESTS[5][1])),tolerance);
+
+  }
+
+  /**
+   * Tests the given Distance function using (Int)-Featurevectors
+   * 
+   * @param tolerance tolerance used for floating point distances
+   * @param distfunc the distance function to test
+   * @param results An array of results for the given Testcases
+   */
+  public void intFeatVectorSet(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double... results) {
+    assertEquals(results[0], distfunc.distance(INTFEATTESTS[0][0], INTFEATTESTS[0][1]), tolerance);
+    assertEquals(results[1], distfunc.distance(INTFEATTESTS[1][0], INTFEATTESTS[1][1]), tolerance);
+    assertEquals(results[2], distfunc.distance(INTFEATTESTS[2][0], INTFEATTESTS[2][1]), tolerance);
+    assertEquals(results[3], distfunc.distance(INTFEATTESTS[3][0], INTFEATTESTS[3][1]), tolerance);
+    assertEquals(results[4], distfunc.distance(INTFEATTESTS[4][0], INTFEATTESTS[4][1]), tolerance);
+    // assertEquals(results[5],
+    // distfunc.distance(INTFEATTESTS[5][0],INTFEATTESTS[5][1]),tolerance);
+
+  }
+
+  /**
+   * Tests the given Distance function using (Int)-Featurevectors
+   * 
+   * @param tolerance tolerance used for floating point distances
+   * @param distfunc the distance function to test
+   * @param results An array of results for the given Testcases
+   */
+  public void intFeatVectorSetVarLen(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double result) {
+    assertEquals(result, distfunc.distance(INTFEATVECTORS[6], INTFEATVECTORS[5]), tolerance);
+    assertEquals(result, distfunc.distance(INTFEATVECTORS[5], INTFEATVECTORS[6]), tolerance);
+
+  }
+
+}

--- a/elki-core-distance/src/test/java/elki/distance/set/AbstractSetDistanceTest.java
+++ b/elki-core-distance/src/test/java/elki/distance/set/AbstractSetDistanceTest.java
@@ -70,13 +70,11 @@ public abstract class AbstractSetDistanceTest extends AbstractDistanceTest {
    * @param results An array of results for the given Testcases
    */
   public void bitVectorSet(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double... results) {
-    assertEquals(results[0], distfunc.distance(TESTS[0][0], TESTS[0][1]), tolerance);
-    assertEquals(results[1], distfunc.distance(TESTS[1][0], TESTS[1][1]), tolerance);
-    assertEquals(results[2], distfunc.distance(TESTS[2][0], TESTS[2][1]), tolerance);
-    assertEquals(results[3], distfunc.distance(TESTS[3][0], TESTS[3][1]), tolerance);
-    assertEquals(results[4], distfunc.distance(TESTS[4][0], TESTS[4][1]), tolerance);
-    // assertEquals(results[5], distfunc.distance(TESTS[5][0],
-    // TESTS[5][1]),tolerance);
+    assertEquals("Settest BitVector 0:", results[0], distfunc.distance(TESTS[0][0], TESTS[0][1]), tolerance);
+    assertEquals("Settest BitVector 1:", results[1], distfunc.distance(TESTS[1][0], TESTS[1][1]), tolerance);
+    assertEquals("Settest BitVector 2:", results[2], distfunc.distance(TESTS[2][0], TESTS[2][1]), tolerance);
+    assertEquals("Settest BitVector 3:", results[3], distfunc.distance(TESTS[3][0], TESTS[3][1]), tolerance);
+    assertEquals("Settest BitVector 4:", results[4], distfunc.distance(TESTS[4][0], TESTS[4][1]), tolerance);
   }
 
   /**
@@ -87,14 +85,11 @@ public abstract class AbstractSetDistanceTest extends AbstractDistanceTest {
    * @param results An array of results for the given Testcases
    */
   public void numberVectorSet(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double... results) {
-    assertEquals(results[0], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[0][0]), IntegerVector.STATIC.newNumberVector(TESTS[0][1])), tolerance);
-    assertEquals(results[1], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[1][0]), IntegerVector.STATIC.newNumberVector(TESTS[1][1])), tolerance);
-    assertEquals(results[2], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[2][0]), IntegerVector.STATIC.newNumberVector(TESTS[2][1])), tolerance);
-    assertEquals(results[3], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[3][0]), IntegerVector.STATIC.newNumberVector(TESTS[3][1])), tolerance);
-    assertEquals(results[4], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[4][0]), IntegerVector.STATIC.newNumberVector(TESTS[4][1])), tolerance);
-    // assertEquals(results[5],
-    // distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[5][0]),IntegerVector.STATIC.newNumberVector(TESTS[5][1])),tolerance);
-
+    assertEquals("Settest NumberVector 0:", results[0], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[0][0]), IntegerVector.STATIC.newNumberVector(TESTS[0][1])), tolerance);
+    assertEquals("Settest NumberVector 1:", results[1], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[1][0]), IntegerVector.STATIC.newNumberVector(TESTS[1][1])), tolerance);
+    assertEquals("Settest NumberVector 2:", results[2], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[2][0]), IntegerVector.STATIC.newNumberVector(TESTS[2][1])), tolerance);
+    assertEquals("Settest NumberVector 3:", results[3], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[3][0]), IntegerVector.STATIC.newNumberVector(TESTS[3][1])), tolerance);
+    assertEquals("Settest NumberVector 4:", results[4], distfunc.distance(IntegerVector.STATIC.newNumberVector(TESTS[4][0]), IntegerVector.STATIC.newNumberVector(TESTS[4][1])), tolerance);
   }
 
   /**
@@ -105,14 +100,11 @@ public abstract class AbstractSetDistanceTest extends AbstractDistanceTest {
    * @param results An array of results for the given Testcases
    */
   public void intFeatVectorSet(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double... results) {
-    assertEquals(results[0], distfunc.distance(INTFEATTESTS[0][0], INTFEATTESTS[0][1]), tolerance);
-    assertEquals(results[1], distfunc.distance(INTFEATTESTS[1][0], INTFEATTESTS[1][1]), tolerance);
-    assertEquals(results[2], distfunc.distance(INTFEATTESTS[2][0], INTFEATTESTS[2][1]), tolerance);
-    assertEquals(results[3], distfunc.distance(INTFEATTESTS[3][0], INTFEATTESTS[3][1]), tolerance);
-    assertEquals(results[4], distfunc.distance(INTFEATTESTS[4][0], INTFEATTESTS[4][1]), tolerance);
-    // assertEquals(results[5],
-    // distfunc.distance(INTFEATTESTS[5][0],INTFEATTESTS[5][1]),tolerance);
-
+    assertEquals("Settest Int-FeatureVector 0:", results[0], distfunc.distance(INTFEATTESTS[0][0], INTFEATTESTS[0][1]), tolerance);
+    assertEquals("Settest Int-FeatureVector 1:", results[1], distfunc.distance(INTFEATTESTS[1][0], INTFEATTESTS[1][1]), tolerance);
+    assertEquals("Settest Int-FeatureVector 2:", results[2], distfunc.distance(INTFEATTESTS[2][0], INTFEATTESTS[2][1]), tolerance);
+    assertEquals("Settest Int-FeatureVector 3:", results[3], distfunc.distance(INTFEATTESTS[3][0], INTFEATTESTS[3][1]), tolerance);
+    assertEquals("Settest Int-FeatureVector 4:", results[4], distfunc.distance(INTFEATTESTS[4][0], INTFEATTESTS[4][1]), tolerance);
   }
 
   /**
@@ -123,8 +115,8 @@ public abstract class AbstractSetDistanceTest extends AbstractDistanceTest {
    * @param results An array of results for the given Testcases
    */
   public void intFeatVectorSetVarLen(double tolerance, AbstractSetDistance<FeatureVector<?>> distfunc, double result) {
-    assertEquals(result, distfunc.distance(INTFEATVECTORS[6], INTFEATVECTORS[5]), tolerance);
-    assertEquals(result, distfunc.distance(INTFEATVECTORS[5], INTFEATVECTORS[6]), tolerance);
+    assertEquals("Settest Int-FeatureVector Varlength 0:", result, distfunc.distance(INTFEATVECTORS[6], INTFEATVECTORS[5]), tolerance);
+    assertEquals("Settest Int-FeatureVector Varlength 1:", result, distfunc.distance(INTFEATVECTORS[5], INTFEATVECTORS[6]), tolerance);
 
   }
 

--- a/elki-core-distance/src/test/java/elki/distance/set/HammingDistanceTest.java
+++ b/elki-core-distance/src/test/java/elki/distance/set/HammingDistanceTest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of ELKI:
+ * Environment for Developing KDD-Applications Supported by Index-Structures
+ *
+ * Copyright (C) 2019
+ * ELKI Development Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package elki.distance.set;
+
+import org.junit.Test;
+
+import elki.utilities.ELKIBuilder;
+
+public class HammingDistanceTest extends AbstractSetDistanceTest {
+
+  final double[] SCORES = { 10, // # a != b = 10
+      5, // # c != d = 5
+      5, // # c != e = 5
+      4, // # a != c = 4
+      3, // # b != d = 3
+      0 // # e != e = 0
+  };
+
+  @Test
+  public void testHammingDistance() {
+    HammingDistance dist = new ELKIBuilder<>(HammingDistance.class).build();
+
+    basicChecks(dist);
+    varyingLengthBasic(1e-10, dist, 1, 0, 1, 1, 2, 1);
+
+    bitVectorSet(1e-10, dist, SCORES);
+    numberVectorSet(1e-10, dist, SCORES);
+    intFeatVectorSet(1e-10, dist, SCORES);
+    intFeatVectorSetVarLen(1e-10, dist, 8);
+
+  }
+
+}

--- a/elki-core-distance/src/test/java/elki/distance/set/JaccardSimilarityDistanceTest.java
+++ b/elki-core-distance/src/test/java/elki/distance/set/JaccardSimilarityDistanceTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of ELKI:
+ * Environment for Developing KDD-Applications Supported by Index-Structures
+ *
+ * Copyright (C) 2019
+ * ELKI Development Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package elki.distance.set;
+
+import org.junit.Test;
+
+import elki.utilities.ELKIBuilder;
+
+public class JaccardSimilarityDistanceTest extends AbstractSetDistanceTest {
+
+  final double[] SCORES = { 1, // a and b / a or b = 0/10 = 0 d = 1
+      .5, // c and d / c or d = 5/10 = 0.5 d = .5
+      1, // c and e / c or e = 0/5 = 0 d = 1
+      2. / 3, // a and c / a or c = 2/6 = 0.3333 d = .66666
+      .3, // b and d / b or d = 7/10 = 0.7 d = .3
+      0 };
+
+  @Test
+  public void testJaccardSimilarityDistance() {
+    JaccardSimilarityDistance dist = new ELKIBuilder<>(JaccardSimilarityDistance.class).build();
+
+    basicChecks(dist);
+    sparseBasic(1e-10, dist, 1, 0, 1, 1, 1, 1);
+    
+    bitVectorSet(1e-10, dist, SCORES);
+    numberVectorSet(1e-10, dist, SCORES);
+    intFeatVectorSet(1e-10, dist, SCORES);
+    intFeatVectorSetVarLen(1e-10, dist, .8);
+  }
+
+}


### PR DESCRIPTION
Added tests for set distances.

Fixed an error in Jaccard similarities in the according distance class and in the bitvector class.
If two empty Vectors were given, the similirarity was NaN but should have been 1 and the distance should be 0.
