### PR TITLE
Fixes for Betula Lloyd k-means

### DIFF
--- a/elki-clustering/src/main/java/elki/clustering/kmeans/BetulaLloydKMeans.java
+++ b/elki-clustering/src/main/java/elki/clustering/kmeans/BetulaLloydKMeans.java
@@ -200,6 +200,7 @@ public class BetulaLloydKMeans extends AbstractKMeans<NumberVector, KMeansModel>
   private double[][] kmeans(ArrayList<? extends ClusterFeature> cfs, int[] assignment, int[] weights, CFTree<?> tree) {
     double[][] means = initialization.chooseInitialMeans(tree, cfs, k);
     for(int i = 1; i <= maxiter || maxiter < 0; i++) {
+      Duration duration = LOG.newDuration(getClass().getName() + "." + i + ".time").begin();
       long prevdiststat = diststat;
       means = i == 1 ? means : means(assignment, means, cfs, weights);
       if(i > 1 && LOG.isStatistics()) {
@@ -209,6 +210,7 @@ public class BetulaLloydKMeans extends AbstractKMeans<NumberVector, KMeansModel>
       }
       int changed = assignToNearestCluster(assignment, means, cfs, weights);
       if(LOG.isStatistics()) {
+        LOG.statistics(duration.end());
         LOG.statistics(new LongStatistic(getClass().getName() + "." + i + ".reassigned", changed));
         if(diststat > prevdiststat) {
           LOG.statistics(new LongStatistic(getClass().getName() + "." + i + ".distance-computations", diststat - prevdiststat));

--- a/elki-clustering/src/main/java/elki/clustering/kmeans/BetulaLloydKMeans.java
+++ b/elki-clustering/src/main/java/elki/clustering/kmeans/BetulaLloydKMeans.java
@@ -237,7 +237,7 @@ public class BetulaLloydKMeans extends AbstractKMeans<NumberVector, KMeansModel>
       int c = assignment[i];
       final ClusterFeature cf = cfs.get(i);
       int d = cf.getDimensionality();
-      int n = cf.getWeight();
+      int n = ignoreWeight ? 1 : cf.getWeight();
       if(newMeans[c] == null) {
         newMeans[c] = new double[d];
         for(int j = 0; j < d; j++) {
@@ -292,7 +292,7 @@ public class BetulaLloydKMeans extends AbstractKMeans<NumberVector, KMeansModel>
         changed++;
         assignment[i] = minIndex;
       }
-      weights[minIndex] += ignoreWeight ? 1 : cfsi.getWeight();
+      weights[minIndex] += cfsi.getWeight();
     }
     return changed;
   }

--- a/elki-clustering/src/test/java/elki/clustering/kmeans/BetulaLloydKMeansTest.java
+++ b/elki-clustering/src/test/java/elki/clustering/kmeans/BetulaLloydKMeansTest.java
@@ -78,8 +78,8 @@ public class BetulaLloydKMeansTest extends AbstractClusterAlgorithmTest {
         .with(AbstractKMeans.K_ID, 4) //
         .with(AbstractCFKMeansInitialization.Par.SEED_ID, 0) //
         .build().autorun(db);
-    assertFMeasure(db, clustering, 0.86656);
-    assertClusterSizes(clustering, new int[] { 85, 127, 203, 223 });
+    assertFMeasure(db, clustering, 0.88199);
+    assertClusterSizes(clustering, new int[] { 76, 141, 202, 219 });
   }
 
   @Test


### PR DESCRIPTION
This fixes the incorrect usage of the naive flag. The previous version did only disregard the weight when initializing the result arrays.

It also adds missing timings that are present for other k-means algorithms.