### PR TITLE
fix: first cf was not excluded in weights for CFKPlusPlusLeaves.

### DIFF
--- a/elki-clustering/src/main/java/elki/clustering/kmeans/initialization/betula/CFKPlusPlusLeaves.java
+++ b/elki-clustering/src/main/java/elki/clustering/kmeans/initialization/betula/CFKPlusPlusLeaves.java
@@ -165,7 +165,11 @@ public class CFKPlusPlusLeaves extends AbstractCFKMeansInitialization {
     double weightsum = 0.;
     int i = 0;
     for(AsClusterFeature cf : cfs) {
-      weightsum += weights[i++] = distance.squaredWeight(first, cf.getCF());
+      if (first == cf) {
+        weights[i++] = 0.;
+      } else {
+        weightsum += weights[i++] = distance.squaredWeight(first, cf.getCF());
+      }
     }
     return weightsum;
   }


### PR DESCRIPTION
When implementing the K-means++ initialization in Rust, I found a discrepancy between the first and all following selected cf's in the Java version. Currently all except the first have their weight set to 0. This should also apply for the first.

I am not entirely sure if there is a faster way to archive that. 